### PR TITLE
Files:getString() now use '\n' to separate lines, nginx host file str…

### DIFF
--- a/src/ServerManager/Files.cpp
+++ b/src/ServerManager/Files.cpp
@@ -24,7 +24,7 @@ string Files::getString(string path)
 		throw "Invalid file";
 	}
 	while (getline(file, line)) {
-		content.append(line);
+		content.append(line + "\n");
 	}
 	file.close();
 


### PR DESCRIPTION
This random error lead me to fix this: `2016/05/07 11:35:22 [emerg] 6861#0: unexpected end of file, expecting "}" in /etc/nginx/sites-enabled/test_test.conf:1'`. Config was OK, so where was the problem? i guess reason was that host.conf was not formatting on lines. And next i am not sure if `String::getString()` function changes do not some problems on other side in code. Can you check this? Thank you!