### PR TITLE
Manager remove: enable regex selecting even in hosts file

### DIFF
--- a/src/ServerManager/Manager.cpp
+++ b/src/ServerManager/Manager.cpp
@@ -145,7 +145,7 @@ string Manager::remove(string hostName)
 	ifstream ihostFile(this->config.hosts.c_str());
 	if (ihostFile.good()) {
 		ihostFile.close();
-		Console rmHost("sed -i /" + hostName + "/d " + this->config.hosts.c_str());
+		Console rmHost("sed --in-place /" + hostName + "/d " + this->config.hosts.c_str());
 		if (rmHost.exec().empty()) {
 			result.append("\nVirtual host/s has been removed from hosts file");
 		}

--- a/src/ServerManager/Manager.cpp
+++ b/src/ServerManager/Manager.cpp
@@ -145,7 +145,7 @@ string Manager::remove(string hostName)
 	ifstream ihostFile(this->config.hosts.c_str());
 	if (ihostFile.good()) {
 		ihostFile.close();
-		Console rmHost("sed --in-place /" + hostName + "/d " + this->config.hosts.c_str());
+		Console rmHost("sed --in-place '/" + hostName + "/d' " + this->config.hosts.c_str());
 		if (rmHost.exec().empty()) {
 			result.append("\nVirtual host/s has been removed from hosts file");
 		}

--- a/src/ServerManager/Manager.cpp
+++ b/src/ServerManager/Manager.cpp
@@ -83,15 +83,27 @@ string Manager::create(string hostName)
 	ofstream nginxConfig(path.c_str());
 	if (nginxConfig.good()) {
 		nginxConfig << this->getServerConfig(hostName);
-		if(nginxConfig.good()) {
+		if (nginxConfig.good()) {
 			result.append("\nAdded virtual host nginx configuration");
 		}
-		Console mkdirLog("mkdir -p " + this->config.htdocs + "/" + hostName + "/" + this->config.log);
-		Console mkdirRoot("mkdir -p " + this->config.htdocs + "/" + hostName + "/" + this->config.root);
-		if (mkdirLog.exec().empty() && mkdirRoot.exec().empty()) {
-			result.append("\nCreated base project directories: ");
-			result.append("\n\t-" + this->config.htdocs + "/" + hostName + "/" + this->config.log);
-			result.append("\n\t-" + this->config.htdocs + "/" + hostName + "/" + this->config.root);
+		if (!this->config.project.empty()) {
+			Console testGitRepository("git ls-remote " + this->config.project + " --exit-code");
+			if (testGitRepository.exec().empty()) {
+					Console cloneGitRepository("git clone " + this->config.project + " " + this->config.htdocs + "/" + hostName);
+					cloneGitRepository.exec();
+					result.append("\nCreated project from git repository");
+			} else {
+				nginxConfig.close();
+				throw "Check if repository of project is valid: " + this->config.project;
+			}
+		} else {
+			Console mkdirLog("mkdir -p " + this->config.htdocs + "/" + hostName + "/" + this->config.log);
+			Console mkdirRoot("mkdir -p " + this->config.htdocs + "/" + hostName + "/" + this->config.root);
+			if (mkdirLog.exec().empty() && mkdirRoot.exec().empty()) {
+				result.append("\nCreated base project directories: ");
+				result.append("\n\t-" + this->config.htdocs + "/" + hostName + "/" + this->config.log);
+				result.append("\n\t-" + this->config.htdocs + "/" + hostName + "/" + this->config.root);
+			}
 		}
 		nginxConfig.close();
 	} else {
@@ -134,7 +146,7 @@ string Manager::remove(string hostName)
 	if (ihostFile.good()) {
 		ihostFile.close();
 		Console rmHost("sed -i /" + hostName + "/d " + this->config.hosts.c_str());
-		if(rmHost.exec().empty()) {
+		if (rmHost.exec().empty()) {
 			result.append("\nVirtual host/s has been removed from hosts file");
 		}
 	} else {

--- a/src/ServerManager/Manager.cpp
+++ b/src/ServerManager/Manager.cpp
@@ -132,13 +132,14 @@ string Manager::remove(string hostName)
 
 	ifstream ihostFile(this->config.hosts.c_str());
 	if (ihostFile.good()) {
+		ihostFile.close();
 		Console rmHost("sed -i /" + hostName + "/d " + this->config.hosts.c_str());
 		if(rmHost.exec().empty()) {
 			result.append("\nVirtual host/s has been removed from hosts file");
 		}
 	} else {
-		throw "Invalid path to hosts file or you don't run as administrator(sudo)";
 		ihostFile.close();
+		throw "Invalid path to hosts file or you don't run as administrator(sudo)";
 	}
 	Console nginxStart("nginx");
 	if (nginxStart.exec().empty()) {

--- a/src/ServerManager/main.cpp
+++ b/src/ServerManager/main.cpp
@@ -41,18 +41,18 @@ int main(int argc, char** argv)
 			manager->setConfiguration(config);
 			cout << formateSuccess(manager->create(argsParser->getParam())) << endl;
 		} else if (argsParser->getAction().compare("remove") == 0) {
-			cout << formateProcess("Removing virtual host:") << endl;
+			cout << formateProcess("Removing virtual hosts:") << endl;
 			manager->setConfiguration(config);
 			cout << formateSuccess(manager->remove(argsParser->getParam())) << endl;
 		} else if (argsParser->getAction().compare("search") == 0) {
 			manager->setConfiguration(config);
-			cout << formateSuccess("Host ");
+			cout << formateSuccess("Virtual hosts ");
 			cout <<	formateProcess(argsParser->getParam());
 			cout << formateSuccess(" has been found in:") << endl;
 			cout << formateProcess(manager->search(argsParser->getParam())) << endl;
 		} else {
 			cout << formateProcess(HELP) << endl;
-		}	
+		}
 	} catch(const char* e) {
 		cerr << formateThrow(e) << endl;
 	}


### PR DESCRIPTION
I found that is possible use something like `github*` in list command `sudo server-manager list github*` but not in remove. Why i would liek solve this? i opened my hosts file and i said: "Jeez, what the fuck"

```

Host github* has been found in:
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   github.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubbb.dev
127.0.0.1   githubb.dev
127.0.0.1   githubbbb.dev
127.0.0.1   githubbbb.dev
127.0.0.1   githubbbbb.dev
127.0.0.1   githubbbbbbb.dev
127.0.0.1   githubbbbbbb.dev

```

So what happens when i use `sudo server-manager remove github*`, everything is removed correctly, project folders, nginx host conf files, but not hosts, there is no change, so please, can you merge it? Thank you!
